### PR TITLE
Replace xargo with cargo

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+[build]
+target = "x86_64-MiauOS.json"
+
+[unstable]
+build-std-features = ["compiler-builtins-mem"]
+build-std = ["core", "compiler_builtins"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,5 @@ authors = ["Marceline Roennfeldt <roen0014@asms.sa.edu.au>"]  # Author(s) of the
 [lib]  # Configuration for the library crate
 crate-type = ["staticlib"]  # Compile the crate as a static library
 
-[unstable]
-build-std-features = ["compiler-builtins-mem"]
-build-std = ["core", "compiler_builtins"]
-
-[build]
-target = "x86_64-MiauOS.json"
-
 [dependencies]  # Dependencies of the package
-volatile = "0.2.6"
+volatile = "0.5.1"

--- a/Makefile
+++ b/Makefile
@@ -34,33 +34,33 @@ all: $(kernel)
 
 # Remove all build artifacts
 clean:
-	@rm -r build
+	 rm -rf build target
 
 # Run the operating system in QEMU
 run: $(iso)
-	@qemu-system-x86_64 -cdrom $(iso)
+	 qemu-system-x86_64 -cdrom $(iso)
 
 # Build the ISO file
 iso: $(iso)
 
 # Create the ISO file
 $(iso): $(kernel) $(grub_cfg)
-	@mkdir -p build/isofiles/boot/grub
-	@cp $(kernel) build/isofiles/boot/kernel.bin
-	@cp $(grub_cfg) build/isofiles/boot/grub
-	@grub-mkrescue -o $(iso) build/isofiles 2> /dev/null
-	@rm -r build/isofiles
+	 mkdir -p build/isofiles/boot/grub
+	 cp $(kernel) build/isofiles/boot/kernel.bin
+	 cp $(grub_cfg) build/isofiles/boot/grub
+	 grub-mkrescue -o $(iso) build/isofiles 2> /dev/null
+	 rm -r build/isofiles
 
 # Build the kernel binary file
 $(kernel): kernel $(rust_os) $(assembly_object_files) $(linker_script)
-	@ld -n -T $(linker_script) -o $(kernel) \
+	 ld -n -T $(linker_script) -o $(kernel) \
 			$(assembly_object_files) $(rust_os)
 
 # Build the Rust object file
 kernel:
-	@RUST_TARGET_PATH=$(shell pwd) xargo build --target $(target)
+	 RUST_TARGET_PATH=$(shell pwd) cargo build --target $(target)
 
 # Compile assembly source files to object files
 build/arch/$(arch)/%.o: src/arch/$(arch)/%.asm
-	@mkdir -p $(shell dirname $@)
-	@nasm -felf64 $< -o $@
+	 mkdir -p $(shell dirname $ )
+	 nasm -felf64 $< -o $ 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ To build and run MiauOS, you will need the following dependencies:
 - grub-mkrescue
 - xorriso
 - grub-pc-bin
-- xargo
 - git
 
 ### Building and Running

--- a/src/vga_buffer.rs
+++ b/src/vga_buffer.rs
@@ -1,3 +1,5 @@
+use volatile::VolatilePtr;
+
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -73,7 +75,8 @@ impl Writer {
         }
     }
 
-    fn new_line(&mut self) {/* TODO */}
+    fn new_line(&mut self) { /* TODO */
+    }
 }
 
 impl Writer {
@@ -85,7 +88,6 @@ impl Writer {
                 // not part of printable ASCII range
                 _ => self.write_byte(0xfe),
             }
-
         }
     }
 }


### PR DESCRIPTION
Xargo is unmaintained(?) as Cargo now has all of Xargo's functionality built in, so it would be good to replace it.

Note that unfortunately external packages still cannot be found by `rustc` - Will work on fixing that.